### PR TITLE
fixed splitting stopping after 18 missions

### DIFF
--- a/mec-autosplitter.asl
+++ b/mec-autosplitter.asl
@@ -79,14 +79,18 @@ split
 	{
 		if((timer.CurrentTime.RealTime - vars.lastSplit).TotalSeconds > 15)
 		{
-			if(settings[vars.compare[vars.splitIteration]])
+			vars.lastSplit = timer.CurrentTime.RealTime;
+			// If we've checked every setting already (for 100%/all missions)
+			if(vars.splitIteration > 17)
 			{
-				vars.splitIteration = vars.splitIteration + 1;
-				vars.lastSplit = timer.CurrentTime.RealTime;
 				return true;
 			}
+			// Incase setting is disabed we still want to increment this
 			vars.splitIteration = vars.splitIteration + 1;
-			vars.lastSplit = timer.CurrentTime.RealTime;
+			if(settings[vars.compare[vars.splitIteration - 1]])
+			{
+				return true;
+			}
 		}
 	}
 	


### PR DESCRIPTION
Currently if you do more than 18 missions (the amount that have setting defined) the autosplitter will stop splitting. This change should make it so it will continue after this point, though you can no longer disable splits.
It launches fine when I add it in the scriptable autosplitter component, but I have yet to test in a full run, can do that if you want.